### PR TITLE
Update address structure in prefill info

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -60,14 +60,14 @@ class PurchaseRequest extends AbstractRequest
                     'name' => $this->getCard()->getName(),
                     'email' => $this->getCard()->getEmail(),
                     'phone_number' => $this->getCard()->getPhone(),
-                    'address' => [
+                    'address' => array(
                         'address1' => $this->getCard()->getAddress1(),
                         'address2' => $this->getCard()->getAddress2(),
                         'city' => $this->getCard()->getCity(),
                         'region' => $this->getCard()->getState(),
                         'country' => $this->getCard()->getCountry(),
                         'postal_code' => $this->getCard()->getPostcode()
-                    ]
+                    )
                 );
 
                 foreach ($prefill_info as $key => $value) {

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -60,11 +60,14 @@ class PurchaseRequest extends AbstractRequest
                     'name' => $this->getCard()->getName(),
                     'email' => $this->getCard()->getEmail(),
                     'phone_number' => $this->getCard()->getPhone(),
-                    'address' => $this->getCard()->getAddress1(),
-                    'city' => $this->getCard()->getCity(),
-                    'state' => $this->getCard()->getState(),
-                    'region' => $this->getRegion(),
-                    'country' => $this->getCard()->getCountry(),
+                    'address' => [
+                        'address1' => $this->getCard()->getAddress1(),
+                        'address2' => $this->getCard()->getAddress2(),
+                        'city' => $this->getCard()->getCity(),
+                        'region' => $this->getCard()->getState(),
+                        'country' => $this->getCard()->getCountry(),
+                        'postal_code' => $this->getCard()->getPostcode()
+                    ]
                 );
 
                 foreach ($prefill_info as $key => $value) {


### PR DESCRIPTION
This change corrects the address structure for API version 2016-07-13.

> New address structure for all endpoints that use address fields. The 'zip' and 'postcode' parameters have been merged and is now called 'postal_code'. Additionally, the 'state' parameter has been replaced by 'region' for all geos.

https://stage.wepay.com/developer/reference/change_log
